### PR TITLE
fix: filter ssh commands where dest is not over ssh

### DIFF
--- a/rsync_time_machine.py
+++ b/rsync_time_machine.py
@@ -31,6 +31,14 @@ class SSH(NamedTuple):
     id_rsa: str | None
 
 
+def dest_is_ssh(ssh: SSH | None):
+    """
+    Returns the SSH if the destination is remote
+    Else returns None.
+    """
+    return ssh if ssh and ssh.dest_folder_prefix else None
+
+
 COLORS = {
     "green": "\033[92m",
     "magenta": "\033[95m",
@@ -257,7 +265,7 @@ def find_backups(dest_folder: str, ssh: SSH | None = None) -> list[str]:
     (Replaces 'fn_find_backups' in the Bash script).
     """
     cmd = f"find '{dest_folder}/' -maxdepth 1 -type d -name '????-??-??-??????' -prune | sort -r"
-    return run_cmd(cmd, ssh).stdout.splitlines()
+    return run_cmd(cmd, dest_is_ssh(ssh)).stdout.splitlines()
 
 
 def expire_backup(
@@ -359,7 +367,7 @@ def backup_marker_path(folder: str) -> str:
 def find_backup_marker(folder: str, ssh: SSH | None = None) -> str | None:
     """Find the backup marker file in the given folder."""
     marker_path = backup_marker_path(folder)
-    output = find(marker_path, ssh)
+    output = find(marker_path, dest_is_ssh(ssh))
     return marker_path if output else None
 
 
@@ -472,9 +480,9 @@ def ln(src: str, dest: str, ssh: SSH | None = None) -> None:
     run_cmd(f"ln -s -- '{src}' '{dest}'", ssh)
 
 
-def test_file_exists_src(path: str) -> bool:
+def test_file_exists_src(path: str, ssh: SSH | None = None) -> bool:
     """Test if a file exists."""
-    return run_cmd(f"test -e '{path}'", None).returncode == 0
+    return run_cmd(f"test -e '{path}'", ssh).returncode == 0
 
 
 def get_file_system_type(path: str, ssh: SSH | None = None) -> str:
@@ -615,8 +623,8 @@ def get_rsync_flags(
         rsync_flags += rsync_append_flags.split()
 
     if (
-        get_file_system_type(src_folder).lower() == "fat"
-        or get_file_system_type(dest_folder, ssh).lower() == "fat"
+        get_file_system_type(src_folder, ssh).lower() == "fat"
+        or get_file_system_type(dest_folder, dest_is_ssh(ssh)).lower() == "fat"
     ):
         log_info("File-system is a version of FAT.")
         log_info("Using the --modify-window rsync parameter with value 2.")
@@ -813,11 +821,11 @@ def backup(
         allow_host_only=allow_host_only,
     )
 
-    if not test_file_exists_src(src_folder):
+    if not test_file_exists_src(src_folder, ssh):
         log_error(f"Source folder '{src_folder}' does not exist - aborting.")
         sys.exit(1)
 
-    check_dest_is_backup_folder(dest_folder, ssh)
+    check_dest_is_backup_folder(dest_folder, dest_is_ssh(ssh))
 
     now = now_str()
     dest = os.path.join(dest_folder, now)
@@ -893,11 +901,11 @@ def backup(
 
     check_rsync_errors(log_file, auto_delete_log)
 
-    rm_file(os.path.join(dest_folder, "latest"), ssh)
+    rm_file(os.path.join(dest_folder, "latest"), dest_is_ssh(ssh))
     ln(
         os.path.basename(dest),
         os.path.join(dest_folder, "latest"),
-        ssh,
+        dest_is_ssh(ssh),
     )
 
     rm_file(inprogress_file, ssh)

--- a/rsync_time_machine.py
+++ b/rsync_time_machine.py
@@ -32,8 +32,7 @@ class SSH(NamedTuple):
 
 
 def dest_is_ssh(ssh: SSH | None):
-    """
-    Returns the SSH if the destination is remote
+    """Returns the SSH if the destination is remote
     Else returns None.
     """
     return ssh if ssh and ssh.dest_folder_prefix else None

--- a/rsync_time_machine.py
+++ b/rsync_time_machine.py
@@ -31,10 +31,8 @@ class SSH(NamedTuple):
     id_rsa: str | None
 
 
-def dest_is_ssh(ssh: SSH | None):
-    """Returns the SSH if the destination is remote
-    Else returns None.
-    """
+def dest_is_ssh(ssh: SSH | None) -> SSH | None:
+    """Returns the SSH object only if the destination is remote."""
     return ssh if ssh and ssh.dest_folder_prefix else None
 
 


### PR DESCRIPTION
This is one possible solution for the issue I'm facing where some commands:
 - check for `backup marker`
 - check that `dest` folder exists
 - creating the `latest` symlink

were actually running on the `src` instead of the `dest`.

Run `verbose` and you would note that some commands are now run locally

Args are: `--verbose josh@edesk.local:/home/josh/Documents /tmp/edesk.local/Documents `

Snipped output shows where some commands which used to be run `remote` are now run locally

```
rsync-time-machine.py: Running remote command: test -e '/home/josh/Documents'
rsync-time-machine.py: Running local command: find '/tmp/edesk.local/Documents/backup.marker'
rsync-time-machine.py: Command output: /tmp/edesk.local/Documents/backup.marker
rsync-time-machine.py: Running local command: find '/tmp/edesk.local/Documents/' -maxdepth 1 -
rsync-time-machine.py: Running remote command: find '/tmp/edesk.local/Documents/backup.inprogress'
...
rsync-time-machine.py: Running local command: rm -f -- '/tmp/edesk.local/Documents/latest'
rsync-time-machine.py: Running local command: ln -s -- '2024-03-25-172323' '/tmp/edesk.local/Documents/latest'
rsync-time-machine.py: Running remote command: rm -f -- '/tmp/edesk.local/Documents/backup.inprogress'
```